### PR TITLE
Improve suggestion display and file browsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,12 +131,22 @@
       padding: 5px 8px;
       border-radius: 4px;
       cursor: pointer;
-      white-space: normal;
       font-size: 12px;
       color: blue;
       display: flex;
       justify-content: space-between;
       align-items: center;
+    }
+
+    .suggestions li span,
+    .file-item span {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .file-item span {
+      flex: 1;
     }
 
     .suggestions li button,
@@ -151,6 +161,7 @@
     .file-item button img {
       width: 16px;
       height: 16px;
+      display: block;
     }
 
     .suggestions li:hover {
@@ -193,7 +204,7 @@
       <div class="suggestions">
         <ul id="suggestionsList"></ul>
       </div>
-      <h3>Department Suggestions</h3>
+      <h3>File based suggestion:</h3>
       <div class="suggestions">
         <ul id="fileSuggestionsList"></ul>
       </div>
@@ -206,7 +217,7 @@
     const fileListDisplay = document.getElementById('fileList');
     let allFiles = [];
 
-    let defaultSuggestions = ['Department of Mathematics', 'Department of Statistics'];
+    let defaultSuggestions = [];
     let fileSuggestions = {};
 
     function getCustomDomains() {
@@ -402,10 +413,11 @@
       generateFileSuggestions();
     }
 
-    function removeFile(index) {
-      allFiles.splice(index, 1);
+   function removeFile(index) {
+     allFiles.splice(index, 1);
       updateFileList();
-    }
+      fileInput.value = '';
+   }
 
     dropArea.addEventListener('dragover', (e) => {
       e.preventDefault();
@@ -429,6 +441,7 @@
 
     fileInput.addEventListener('change', () => {
       allFiles = allFiles.concat(Array.from(fileInput.files));
+      fileInput.value = '';
       updateFileList();
     });
 


### PR DESCRIPTION
## Summary
- align delete icons properly by ensuring icon images display as blocks
- prevent wrapped text for suggestions and uploaded file names
- rename Department Suggestions section to File based suggestion
- clear file input after adding or removing to allow re-browsing
- remove the built-in department suggestions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f60b721f08323a8f99be6329acbf0