### PR TITLE
Fix common keywords dropdown overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,13 +179,10 @@
       margin-bottom: 15px;
     }
     .common-keywords select {
-      padding-right: 30px;
+      padding-right: 0;
     }
     #addCommonKeyword {
-      position: absolute;
-      right: 5px;
-      top: 50%;
-      transform: translateY(-50%);
+      margin-left: 5px;
       background: none;
       border: none;
       cursor: pointer;


### PR DESCRIPTION
## Summary
- ensure the add keyword button no longer overlaps the dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b1ebcadcc8323bda82ef42f40c8bd