### PR TITLE
Fix plus icon visibility for adding keywords

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
       background: none;
       border: none;
       cursor: pointer;
+      color: #007bff;
     }
 
 


### PR DESCRIPTION
## Summary
- set `#addSuggestion` text color to blue so the `+` symbol is visible

## Testing
- `ls -a`


------
https://chatgpt.com/codex/tasks/task_e_688b38b9705883239fc825e048300eaf